### PR TITLE
Fix mumps issue

### DIFF
--- a/optalg/lin_solver/_mumps/_dmumps.pyx
+++ b/optalg/lin_solver/_mumps/_dmumps.pyx
@@ -14,7 +14,7 @@ DMUMPS_REAL_DTYPE = 'd'
 DMUMPS_COMPLEX_DTYPE = 'd'
 
 from libc.string cimport strncpy
-
+from libc.stdint cimport uintptr_t
 cdef extern from "dmumps_c.h":
 
     ctypedef int MUMPS_INT

--- a/optalg/lin_solver/_mumps/_dmumps.pyx
+++ b/optalg/lin_solver/_mumps/_dmumps.pyx
@@ -1,5 +1,6 @@
 """
 - Changed "long" to "unsigned long" (Tomas Tinoco De Rubira, 01/11/2014)
+- Changed "unsigned long" to "uintptr_t" (Tamer Ibrahim, 04/19/2020)
 - Separated variable definitions into multipler lines (Tomas Tinoco De Rubira, 06/02/2017)
 """
 
@@ -15,6 +16,7 @@ DMUMPS_COMPLEX_DTYPE = 'd'
 
 from libc.string cimport strncpy
 from libc.stdint cimport uintptr_t
+
 cdef extern from "dmumps_c.h":
 
     ctypedef int MUMPS_INT

--- a/optalg/lin_solver/_mumps/_dmumps.pyx
+++ b/optalg/lin_solver/_mumps/_dmumps.pyx
@@ -148,82 +148,82 @@ cdef class DMUMPS_STRUC_C:
         def __get__(self): return self.ob.nz
         def __set__(self, value): self.ob.nz = value
     property irn:
-        def __get__(self): return <unsigned long> self.ob.irn
-        def __set__(self, unsigned long value): self.ob.irn = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.irn
+        def __set__(self, uintptr_t value): self.ob.irn = <MUMPS_INT*> value
     property jcn:
-        def __get__(self): return <unsigned long> self.ob.jcn
-        def __set__(self, unsigned long value): self.ob.jcn = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.jcn
+        def __set__(self, uintptr_t value): self.ob.jcn = <MUMPS_INT*> value
     property a:
-        def __get__(self): return <unsigned long> self.ob.a
-        def __set__(self, unsigned long value): self.ob.a = <DMUMPS_COMPLEX*> value
+        def __get__(self): return <uintptr_t> self.ob.a
+        def __set__(self, uintptr_t value): self.ob.a = <DMUMPS_COMPLEX*> value
 
     property nz_loc:
         def __get__(self): return self.ob.nz_loc
         def __set__(self, value): self.ob.nz_loc = value
     property irn_loc:
-        def __get__(self): return <unsigned long> self.ob.irn_loc
-        def __set__(self, unsigned long value): self.ob.irn_loc = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.irn_loc
+        def __set__(self, uintptr_t value): self.ob.irn_loc = <MUMPS_INT*> value
     property jcn_loc:
-        def __get__(self): return <unsigned long> self.ob.jcn_loc
-        def __set__(self, unsigned long value): self.ob.jcn_loc = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.jcn_loc
+        def __set__(self, uintptr_t value): self.ob.jcn_loc = <MUMPS_INT*> value
     property a_loc:
-        def __get__(self): return <unsigned long> self.ob.a_loc
-        def __set__(self, unsigned long value): self.ob.a_loc = <DMUMPS_COMPLEX*> value
+        def __get__(self): return <uintptr_t> self.ob.a_loc
+        def __set__(self, uintptr_t value): self.ob.a_loc = <DMUMPS_COMPLEX*> value
 
     property nelt:
         def __get__(self): return self.ob.nelt
         def __set__(self, value): self.ob.nelt = value
     property eltptr:
-        def __get__(self): return <unsigned long> self.ob.eltptr
-        def __set__(self, unsigned long value): self.ob.eltptr = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.eltptr
+        def __set__(self, uintptr_t value): self.ob.eltptr = <MUMPS_INT*> value
     property eltvar:
-        def __get__(self): return <unsigned long> self.ob.eltvar
-        def __set__(self, unsigned long value): self.ob.eltvar = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.eltvar
+        def __set__(self, uintptr_t value): self.ob.eltvar = <MUMPS_INT*> value
     property a_elt:
-        def __get__(self): return <unsigned long> self.ob.a_elt
-        def __set__(self, unsigned long value): self.ob.a_elt = <DMUMPS_COMPLEX*> value
+        def __get__(self): return <uintptr_t> self.ob.a_elt
+        def __set__(self, uintptr_t value): self.ob.a_elt = <DMUMPS_COMPLEX*> value
 
     property perm_in:
-        def __get__(self): return <unsigned long> self.ob.perm_in
-        def __set__(self, unsigned long value): self.ob.perm_in = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.perm_in
+        def __set__(self, uintptr_t value): self.ob.perm_in = <MUMPS_INT*> value
 
     property sym_perm:
-        def __get__(self): return <unsigned long> self.ob.sym_perm
-        def __set__(self, unsigned long value): self.ob.sym_perm = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.sym_perm
+        def __set__(self, uintptr_t value): self.ob.sym_perm = <MUMPS_INT*> value
     property uns_perm:
-        def __get__(self): return <unsigned long> self.ob.uns_perm
-        def __set__(self, unsigned long value): self.ob.uns_perm = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.uns_perm
+        def __set__(self, uintptr_t value): self.ob.uns_perm = <MUMPS_INT*> value
 
     property colsca:
-        def __get__(self): return <unsigned long> self.ob.colsca
-        def __set__(self, unsigned long value): self.ob.colsca = <DMUMPS_REAL*> value
+        def __get__(self): return <uintptr_t> self.ob.colsca
+        def __set__(self, uintptr_t value): self.ob.colsca = <DMUMPS_REAL*> value
     property rowsca:
-        def __get__(self): return <unsigned long> self.ob.rowsca
-        def __set__(self, unsigned long value): self.ob.rowsca = <DMUMPS_REAL*> value
+        def __get__(self): return <uintptr_t> self.ob.rowsca
+        def __set__(self, uintptr_t value): self.ob.rowsca = <DMUMPS_REAL*> value
 
     property rhs:
-        def __get__(self): return <unsigned long> self.ob.rhs
-        def __set__(self, unsigned long value): self.ob.rhs = <DMUMPS_COMPLEX*> value
+        def __get__(self): return <uintptr_t> self.ob.rhs
+        def __set__(self, uintptr_t value): self.ob.rhs = <DMUMPS_COMPLEX*> value
     property redrhs:
-        def __get__(self): return <unsigned long> self.ob.redrhs
-        def __set__(self, unsigned long value): self.ob.redrhs = <DMUMPS_COMPLEX*> value
+        def __get__(self): return <uintptr_t> self.ob.redrhs
+        def __set__(self, uintptr_t value): self.ob.redrhs = <DMUMPS_COMPLEX*> value
     property rhs_sparse:
-        def __get__(self): return <unsigned long> self.ob.rhs_sparse
-        def __set__(self, unsigned long value): self.ob.rhs_sparse = <DMUMPS_COMPLEX*> value
+        def __get__(self): return <uintptr_t> self.ob.rhs_sparse
+        def __set__(self, uintptr_t value): self.ob.rhs_sparse = <DMUMPS_COMPLEX*> value
     property sol_loc:
-        def __get__(self): return <unsigned long> self.ob.sol_loc
-        def __set__(self, unsigned long value): self.ob.sol_loc = <DMUMPS_COMPLEX*> value
+        def __get__(self): return <uintptr_t> self.ob.sol_loc
+        def __set__(self, uintptr_t value): self.ob.sol_loc = <DMUMPS_COMPLEX*> value
 
 
     property irhs_sparse:
-        def __get__(self): return <unsigned long> self.ob.irhs_sparse
-        def __set__(self, unsigned long value): self.ob.irhs_sparse = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.irhs_sparse
+        def __set__(self, uintptr_t value): self.ob.irhs_sparse = <MUMPS_INT*> value
     property irhs_ptr:
-        def __get__(self): return <unsigned long> self.ob.irhs_ptr
-        def __set__(self, unsigned long value): self.ob.irhs_ptr = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.irhs_ptr
+        def __set__(self, uintptr_t value): self.ob.irhs_ptr = <MUMPS_INT*> value
     property isol_loc:
-        def __get__(self): return <unsigned long> self.ob.isol_loc
-        def __set__(self, unsigned long value): self.ob.isol_loc = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.isol_loc
+        def __set__(self, uintptr_t value): self.ob.isol_loc = <MUMPS_INT*> value
 
     property nrhs:
         def __get__(self): return self.ob.nrhs
@@ -287,28 +287,28 @@ cdef class DMUMPS_STRUC_C:
         def __get__(self): return self.ob.deficiency
         def __set__(self, value): self.ob.deficiency = value
     property pivnul_list:
-        def __get__(self): return <unsigned long> self.ob.pivnul_list
-        def __set__(self, unsigned long value): self.ob.pivnul_list = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.pivnul_list
+        def __set__(self, uintptr_t value): self.ob.pivnul_list = <MUMPS_INT*> value
     property mapping:
-        def __get__(self): return <unsigned long> self.ob.mapping
-        def __set__(self, unsigned long value): self.ob.mapping = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.mapping
+        def __set__(self, uintptr_t value): self.ob.mapping = <MUMPS_INT*> value
 
     property size_schur:
         def __get__(self): return self.ob.size_schur
         def __set__(self, value): self.ob.size_schur = value
     property listvar_schur:
-        def __get__(self): return <unsigned long> self.ob.listvar_schur
-        def __set__(self, unsigned long value): self.ob.listvar_schur = <MUMPS_INT*> value
+        def __get__(self): return <uintptr_t> self.ob.listvar_schur
+        def __set__(self, uintptr_t value): self.ob.listvar_schur = <MUMPS_INT*> value
     property schur:
-        def __get__(self): return <unsigned long> self.ob.schur
-        def __set__(self, unsigned long value): self.ob.schur = <DMUMPS_COMPLEX*> value
+        def __get__(self): return <uintptr_t> self.ob.schur
+        def __set__(self, uintptr_t value): self.ob.schur = <DMUMPS_COMPLEX*> value
 
     property instance_number:
         def __get__(self): return self.ob.instance_number
         def __set__(self, value): self.ob.instance_number = value
     property wk_user:
-        def __get__(self): return <unsigned long> self.ob.wk_user
-        def __set__(self, unsigned long value): self.ob.wk_user = <DMUMPS_COMPLEX*> value
+        def __get__(self): return <uintptr_t> self.ob.wk_user
+        def __set__(self, uintptr_t value): self.ob.wk_user = <DMUMPS_COMPLEX*> value
 
     property version_number:
         def __get__(self):


### PR DESCRIPTION
Hey @awig and @swaroopguggilam 

I tried the following changes in 
**_dmumps.pyx** file: 
```from libc.stdint cimport uintptr_t```
replaced all ```unsigned long```  with ```uintptr_t```  as suggested here:  https://northstar-www.dartmouth.edu/doc/solaris-forte/manuals/c/user_guide/conv_v9.html

The package is compiled and installed successfully. I passed all tests : 

```
test_mumps (tests.test_lin_solvers.TestOptSolvers) ... ok
test_superlu (tests.test_lin_solvers.TestOptSolvers) ... ok
test_umfpack (tests.test_lin_solvers.TestOptSolvers) ... SKIP: no umfpack
test_augl_barrier (tests.test_opt_solvers.TestOptSolvers) ... ok
test_augl_properties_support (tests.test_opt_solvers.TestOptSolvers) ... ok
test_cbc (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no cbc
test_cbc_cmd (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no cbc command-line solver
test_cbc_cmd_lp_duals (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no cbc cmd
test_cbc_cmd_properties_support (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no cbc cmd
test_cbc_properties_support (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no cbc
test_clp (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no clp
test_clp_cmd (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no clp command-line solver
test_clp_cmd_lp_duals (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no clp cmd
test_clp_cmd_properties_support (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no clp cmd
test_clp_properties_support (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no clp
test_cplex_cmd (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no cplex command-line solver
test_cplex_cmd_lp_duals (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no cplex cmd
test_cplex_cmd_properties_support (tests.test_opt_solvers.TestOptSolvers) ... SKIP: no cplex cmd
test_inlp_properties_support (tests.test_opt_solvers.TestOptSolvers) ... ok
test_ipopt (tests.test_opt_solvers.TestOptSolvers) ... ok
test_ipopt_lp_duals (tests.test_opt_solvers.TestOptSolvers) ... ok
test_ipopt_properties_support (tests.test_opt_solvers.TestOptSolvers) ... ok
test_iqp_properties_support (tests.test_opt_solvers.TestOptSolvers) ... ok
test_iqp_random (tests.test_opt_solvers.TestOptSolvers) ... ok
test_nr_properties_support (tests.test_opt_solvers.TestOptSolvers) ... ok
test_solvers_on_LPs (tests.test_opt_solvers.TestOptSolvers) ... ok
test_solvers_on_QPs (tests.test_opt_solvers.TestOptSolvers) ... ok
test_lin_to_lp_file (tests.test_problems.TestProblems) ... ok
test_mixintlin_to_lp_file (tests.test_problems.TestProblems) ... ok

----------------------------------------------------------------------
Ran 29 tests in 6.188s

OK (SKIP=14)
```


I want to test all solvers as all of them will use mumps as a default linear solver. all solvers must be tested by trying to solve a problem and compare the results before/after the proposed solution. 

Please check these changes out and let me know how we make sure this changes will not break something else. 