### PR TITLE
Install CBC solver for windows users! 

### DIFF
--- a/build_lib.bat
+++ b/build_lib.bat
@@ -22,3 +22,18 @@ IF "%OPTALG_IPOPT%" == "true" (
         python setup.py setopt --command build -o compiler -s msvc
     )
 )
+IF "%OPTALG_CBC%" == "true" ( 
+    IF NOT EXIST "lib/cbc" (
+    	mkdir lib
+    	cd lib
+    	bitsadmin /transfer "JobName" https://bintray.com/coin-or/download/download_file?file_path=Cbc-refactor-win64-msvc16-mdd.zip "%cd%\lib\CBC.zip"
+    	mkdir cbc
+	7z x CBC.zip -o./cbc 
+	ren cbc\lib\Cbc.dll.lib CbcSolver.lib
+	move "%cd%\lib\cbc\include\coin-or" "%cd%\lib\cbc\include\coin"
+        copy cbc\lib\*.lib ..\optalg\opt_solver\_cbc
+	copy cbc\bin\*.dll ..\optalg\opt_solver\_cbc
+  	cd ..\
+	python setup.py setopt --command build -o compiler -s msvc
+     )
+)

--- a/clean.bat
+++ b/clean.bat
@@ -8,6 +8,7 @@ rmdir /s /q %~dp0build
 rmdir /s /q %~dp0dist
 rmdir /s /q %~dp0OPTALG.egg-info
 rmdir /s /q %~dp0lib\ipopt
+rmdir /s /q %~dp0lib\cbc
 del /s /f %~dp0lib\clp*
 del /s /f %~dp0lib\cbc*
 del /s /f %~dp0lib\Ipopt*


### PR DESCRIPTION
Hey @awig, 

I wish you are doing well.

I would like to use CBC solver to solve simple MILP (small problem, no need for commercial solvers).  I want to use OPTALG with CBC as we already have the interface. 

CBC is not working in windows and I am trying to install it. I modified the build file and add the static link to get the binaries of CBC, then copy the *.DLL files to optalg/opt_solver/_cbc folder.  

It seems it is working fine (I am able to run the example). Would you please check the modification or guide me if I need to do some tests? Do I need to build the library first or I can use the binaries directly! (Building the library is not easy in windows.) 

Thanks in advance! 
