### PR TITLE
Improved Error Messaging on AugL solver

### DIFF
--- a/optalg/opt_solver/augl.py
+++ b/optalg/opt_solver/augl.py
@@ -310,10 +310,9 @@ class OptSolverAugL(OptSolver):
             a2 = np.min(((barrier.umin-self.x)[pneg])/(p[pneg])) if pneg.sum() else np.inf
             alpha_max = 0.98*min([a1,a2])
             if not alpha_max:
-                ind1 = np.where((barrier.umax-self.x) < 1e-15)[0]  # first of tuple
-                ind2 = np.where((barrier.umin-self.x) > -1e-15)[0] # first of tuple
-                vios = np.concatenate((ind1, ind2), axis=0)
-                vio_list = [int(i) for i in vios if i.size > 0]
+                ind1 = np.where((barrier.umax-self.x) == 0)[0]
+                ind2 = np.where((barrier.umin-self.x) == 0)[0]
+                vio_list = [i for i in ind2]+[i for i in ind1]
                 raise OptSolverError_NarrowBounded(self, indexes=vio_list)
 
             try:
@@ -601,7 +600,8 @@ class AugLBarrier:
         self.Hphi_data[:] = 1./np.square(dumin)+1./np.square(dumax)
 
         ind_Hdata = (-self.Hphi_data).argsort()[:5] # index of top 5 Hdata
-        self.VarsAtBounds['index_max_H'] = ind_Hdata
+        if len(vio_u) > 0:
+            self.VarsAtBounds['index_max_H'] = ind_Hdata
 
     def to_interior(self,x, eps=1e-5):
 

--- a/optalg/opt_solver/augl.py
+++ b/optalg/opt_solver/augl.py
@@ -286,7 +286,11 @@ class OptSolverAugL(OptSolver):
 
             # Check penalty
             if self.sigma < sigma_min:
-                raise OptSolverError_SmallPenalty(self)
+                if barrier.VarsAtBounds['indexes']:
+                    vio_list = barrier.VarsAtBounds['indexes']
+                else:
+                    vio_list = None
+                raise OptSolverError_SmallPenalty(self, indexes=vio_list)
 
             # Check custom terminations
             for t in self.terminations:
@@ -306,8 +310,7 @@ class OptSolverAugL(OptSolver):
                 ind2 = np.where((barrier.umin-self.x) > -1e-15)[0] # first of tuple
                 vios = np.concatenate((ind1, ind2), axis=0)
                 vio_list = [int(i) for i in vios if i.size > 0]
-                vio_string = ','.join(map(str, vio_list))
-                raise OptSolverError_NarrowBounded(self, vio_string)
+                raise OptSolverError_NarrowBounded(self, indexes=vio_list)
 
             try:
 
@@ -573,6 +576,9 @@ class AugLBarrier:
         self.Hphi_data = np.zeros(n)
         self.Hphi = coo_matrix((self.Hphi_data,(self.Hphi_row,self.Hphi_col)),shape=(n,n))
 
+        self.VarsAtBounds = {'indexes': [],
+                             'index_max_H': []}
+
     def eval(self,u):
 
         assert(u.size == self.n)
@@ -580,9 +586,19 @@ class AugLBarrier:
         dumax = np.maximum(self.umax-u,1e-12)
         dumin = np.maximum(u-self.umin,1e-12)
 
+        ind1 = np.where(dumax <= 1e-12)[0]
+        ind2 = np.where(dumin <= 1e-12)[0]
+        vio_u = [i for i in ind2]+[i for i in ind1]
+        if len(vio_u) > 0:
+            self.VarsAtBounds['indexes'] = vio_u
+
         self.phi = -np.sum(np.log(dumax)+np.log(dumin))
         self.gphi[:] = -1./dumin+1./dumax
         self.Hphi_data[:] = 1./np.square(dumin)+1./np.square(dumax)
+
+        ind_Hdata = (-self.Hphi_data).argsort()[:5] # index of top 5 Hdata
+        if len(vio_u) > 0:
+            self.VarsAtBounds['index_max_H'] = ind_Hdata
 
     def to_interior(self,x, eps=1e-5):
 

--- a/optalg/opt_solver/augl.py
+++ b/optalg/opt_solver/augl.py
@@ -282,7 +282,11 @@ class OptSolverAugL(OptSolver):
 
             # Check total maxiters
             if self.k >= maxiter:
-                raise OptSolverError_MaxIters(self)
+                if barrier.VarsAtBounds['indexes']:
+                    vio_list = barrier.VarsAtBounds['indexes']
+                else:
+                    vio_list = barrier.VarsAtBounds['index_max_H']
+                raise OptSolverError_MaxIters(self, indexes=vio_list)
 
             # Check penalty
             if self.sigma < sigma_min:
@@ -597,8 +601,7 @@ class AugLBarrier:
         self.Hphi_data[:] = 1./np.square(dumin)+1./np.square(dumax)
 
         ind_Hdata = (-self.Hphi_data).argsort()[:5] # index of top 5 Hdata
-        if len(vio_u) > 0:
-            self.VarsAtBounds['index_max_H'] = ind_Hdata
+        self.VarsAtBounds['index_max_H'] = ind_Hdata
 
     def to_interior(self,x, eps=1e-5):
 

--- a/optalg/opt_solver/opt_solver.py
+++ b/optalg/opt_solver/opt_solver.py
@@ -234,7 +234,14 @@ class OptSolver:
             else:
                 s = (l + u)/2.
 
-        raise OptSolverError_LineSearch(self)
+        try:
+            if self.barrier.VarsAtBounds['indexes']:
+                vio_list = self.barrier.VarsAtBounds['indexes']
+            else:
+                vio_list = None
+            raise OptSolverError_LineSearch(self, indexes=vio_list)
+        except:
+            raise OptSolverError_LineSearch(self)
 
     def reset(self):
         """

--- a/optalg/opt_solver/opt_solver_error.py
+++ b/optalg/opt_solver/opt_solver_error.py
@@ -134,8 +134,8 @@ class OptSolverError_NoInterior(OptSolverError):
         OptSolverError.__init__(self, solver, 'empty interior')
 
 class OptSolverError_MaxIters(OptSolverError):
-    def __init__(self, solver=None):
-        OptSolverError.__init__(self, solver, 'maximum number of iterations')
+    def __init__(self, solver=None, indexes=None):
+        OptSolverError.__init__(self, solver, 'maximum number of iterations', indexes=indexes)
 
 class OptSolverError_SmallPenalty(OptSolverError):
     def __init__(self, solver=None, indexes=None):

--- a/optalg/opt_solver/opt_solver_error.py
+++ b/optalg/opt_solver/opt_solver_error.py
@@ -9,11 +9,12 @@
 
 class OptSolverError(Exception):
 
-    def __init__(self, solver, value):
+    def __init__(self, solver, value, indexes=None):
         if solver:
             solver.set_status(solver.STATUS_ERROR)
             solver.set_error_msg(value)
         self.value = value
+        self.indexes = indexes
 
     def __str__(self):
         return str(self.value)
@@ -97,12 +98,12 @@ class OptSolverError_NumProblems(OptSolverError):
         OptSolverError.__init__(self, solver, 'numerical problems')
 
 class OptSolverError_NarrowBounded(OptSolverError):
-    def __init__(self, solver=None, value=None):
-        OptSolverError.__init__(self, solver, 'narrow bounded '+value)
+    def __init__(self, solver=None, indexes=None):
+        OptSolverError.__init__(self, solver, 'narrow bounded', indexes=indexes)
 
 class OptSolverError_LineSearch(OptSolverError):
-    def __init__(self, solver=None):
-        OptSolverError.__init__(self, solver, 'line search failed')
+    def __init__(self, solver=None, indexes=None):
+        OptSolverError.__init__(self, solver, 'line search failed', indexes=indexes)
 
 class OptSolverError_BadProblemType(OptSolverError):
     def __init__(self, solver=None):
@@ -137,8 +138,8 @@ class OptSolverError_MaxIters(OptSolverError):
         OptSolverError.__init__(self, solver, 'maximum number of iterations')
 
 class OptSolverError_SmallPenalty(OptSolverError):
-    def __init__(self, solver=None):
-        OptSolverError.__init__(self, solver, 'penalty parameter too small')
+    def __init__(self, solver=None, indexes=None):
+        OptSolverError.__init__(self, solver, 'penalty parameter too small', indexes=indexes)
 
 class OptSolverError_BadInitPoint(OptSolverError):
     def __init__(self, solver=None):


### PR DESCRIPTION
### Issue Address

In failed power flows with AugL solver, some errors like "penalty number too small" is confusing to users, if we provide more insights on the variables that are violating their boundaries, or have high Hphi data, in the last iteration, debugging on the power flow failure would be easier. This PR improved the error message reporting on:
- add indexes of variables that are violating the boundaries. 
- if no variables violate the boundary, add indexes of variables that have high Hphi data.
- return the indexes in OptSolverError, still keep none index as the default to be compatible with other projects.

### Tests

- [ ] Tests in OBC/SRN