### PR TITLE
Import dll files with winmode=0 to avoid dll importing error. Modify …

### DIFF
--- a/build_lib.bat
+++ b/build_lib.bat
@@ -18,6 +18,7 @@ IF "%OPTALG_IPOPT%" == "true" (
         cd ..
         copy lib\Ipopt-vc10.dll ..\..\optalg\opt_solver\_ipopt
         copy lib\IpOptFSS.dll ..\..\optalg\opt_solver\_ipopt
+	copy lib\libiomp5md.dll ..\..\optalg\opt_solver\_ipopt
         copy lib\IpOptFSS.dll ..\..\optalg\lin_solver\_mumps
 	copy lib\libiomp5md.dll ..\..\optalg\lin_solver\_mumps
         cd ..\..\

--- a/build_lib.bat
+++ b/build_lib.bat
@@ -2,25 +2,24 @@ IF "%OPTALG_IPOPT%" == "true" (
     IF NOT EXIST "lib\ipopt" (
 	mkdir lib
         cd lib
-        bitsadmin /transfer "JobName" https://www.coin-or.org/download/binary/Ipopt/Ipopt-3.11.1-win64-intel13.1.zip "%cd%\lib\ipopt.zip"
+        bitsadmin /transfer "JobName" /priority FOREGROUND https://www.coin-or.org/download/binary/Ipopt/Ipopt-3.11.1-win64-intel13.1.zip "%cd%\lib\ipopt.zip"
         7z x ipopt.zip
         for /d %%G in ("Ipopt*") do move "%%~G" ipopt
         cd ipopt
       	mkdir temp
         cd temp
-        bitsadmin /transfer "JobName" https://www.coin-or.org/download/binary/Ipopt/Ipopt-3.11.0-Win32-Win64-dll.7z "%cd%\lib\ipopt\temp\foo.7z"
+        bitsadmin /transfer "JobName" /priority FOREGROUND https://www.coin-or.org/download/binary/Ipopt/Ipopt-3.11.0-Win32-Win64-dll.7z "%cd%\lib\ipopt\temp\foo.7z"
         7z x foo.7z
         copy lib\x64\ReleaseMKL\IpOptFSS.dll ..\lib
         copy lib\x64\ReleaseMKL\IpOptFSS.lib ..\lib
-		copy lib\x64\ReleaseMKL\libiomp5md.dll ..\lib
+	copy lib\x64\ReleaseMKL\libiomp5md.dll ..\lib
         copy lib\x64\ReleaseMKL\IpOpt-vc10.dll ..\lib
         copy lib\x64\ReleaseMKL\IpOpt-vc10.lib ..\lib
         cd ..
         copy lib\Ipopt-vc10.dll ..\..\optalg\opt_solver\_ipopt
         copy lib\IpOptFSS.dll ..\..\optalg\opt_solver\_ipopt
-		copy lib\libiomp5md.dll ..\..\optalg\lin_solver\_ipopt
         copy lib\IpOptFSS.dll ..\..\optalg\lin_solver\_mumps
-		copy lib\libiomp5md.dll ..\..\optalg\lin_solver\_mumps
+	copy lib\libiomp5md.dll ..\..\optalg\lin_solver\_mumps
         cd ..\..\
 
         python setup.py setopt --command build -o compiler -s msvc

--- a/optalg/opt_solver/_ipopt/__init__.py
+++ b/optalg/opt_solver/_ipopt/__init__.py
@@ -10,6 +10,7 @@ import sys
 if sys.platform[:3].lower() == "win":
     import ctypes as cts
     import os
+    cts.CDLL(os.path.join(os.path.dirname(os.path.abspath(__file__)), "libiomp5md.dll"), winmode=0)
     cts.CDLL(os.path.join(os.path.dirname(os.path.abspath(__file__)), "IpOptFSS.dll"), winmode=0)
     cts.CDLL(os.path.join(os.path.dirname(os.path.abspath(__file__)), "IpOpt-vc10.dll"), winmode=0)
 

--- a/optalg/opt_solver/_ipopt/__init__.py
+++ b/optalg/opt_solver/_ipopt/__init__.py
@@ -6,5 +6,12 @@
 # OPTALG is released under the BSD 2-clause license. #
 #****************************************************#
 
+import sys
+if sys.platform[:3].lower() == "win":
+    import ctypes as cts
+    import os
+    cts.CDLL(os.path.join(os.path.dirname(os.path.abspath(__file__)), "IpOptFSS.dll"), winmode=0)
+    cts.CDLL(os.path.join(os.path.dirname(os.path.abspath(__file__)), "IpOpt-vc10.dll"), winmode=0)
+
 from .cipopt import *
 


### PR DESCRIPTION
Ctype library for python > 3.8 added a new flag winmode which messes up the importing if not assigned correctly. I fixed this issue! I tried with base Python 3.10, 3.11, and 3.9, and the installation works fine for all versions. 

I updated the build_lib batch file to include the fix that Armaan mentioned to be able to download the files (For some reason, it was blocked before)
